### PR TITLE
Connect to trigger each time it is created

### DIFF
--- a/Sources/Liquid/PrivateViews/LiquidCircleView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidCircleView.swift
@@ -11,16 +11,17 @@ import Combine
 struct LiquidCircleView: View {
     @State var samples: Int
     @State var radians: AnimatableArray
-    @State var cancellable: Cancellable?
     let period: TimeInterval
     let trigger: Timer.TimerPublisher
-    
+
+    var cancellable: Cancellable?
+
     init(samples: Int, period: TimeInterval) {
         self._samples = .init(initialValue: samples)
-        self.trigger = Timer.TimerPublisher(interval: period, runLoop: .main, mode: .common)
-        self.period = period
         self._radians = .init(initialValue: AnimatableArray(LiquidCircleView.generateRadial(samples)))
-        self._cancellable = .init(initialValue: .none)
+        self.period = period
+        self.trigger = Timer.TimerPublisher(interval: period, runLoop: .main, mode: .common)
+        self.cancellable = trigger.connect()
     }
     
     var body: some View {
@@ -29,7 +30,6 @@ struct LiquidCircleView: View {
             .onReceive(trigger) { _ in
                 self.radians = AnimatableArray(LiquidCircleView.generateRadial(self.samples))
             }.onAppear {
-                self.cancellable = self.trigger.connect()
                 self.radians = AnimatableArray(LiquidCircleView.generateRadial(self.samples))
             }.onDisappear {
                 self.cancellable?.cancel()

--- a/Sources/Liquid/PrivateViews/LiquidPathView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidPathView.swift
@@ -15,15 +15,16 @@ struct LiquidPathView: View {
     @State var x: AnimatableArray = .zero
     @State var y: AnimatableArray = .zero
     @State var samples: Int
-    @State var cancellable: Cancellable?
     let period: TimeInterval
     let trigger: Timer.TimerPublisher
-    
+
+    var cancellable: Cancellable?
+
     init(path: CGPath, interpolate: Int, samples: Int, period: TimeInterval) {
         self._samples = .init(initialValue: samples)
-        self.trigger = Timer.TimerPublisher(interval: period, runLoop: .main, mode: .common)
         self.period = period
-        self._cancellable = .init(initialValue: .none)
+        self.trigger = Timer.TimerPublisher(interval: period, runLoop: .main, mode: .common)
+        self.cancellable = self.trigger.connect()
         self.pointCloud = path.getPoints().interpolate(interpolate)
     }
     
@@ -39,7 +40,6 @@ struct LiquidPathView: View {
             .onReceive(trigger) { _ in
                 self.generate()
             }.onAppear {
-                self.cancellable = self.trigger.connect()
                 self.generate()
             }.onDisappear {
                 self.cancellable?.cancel()


### PR DESCRIPTION
In SwiftUI `init` may be called multiple times when the view is already shown (overwriting the initial `trigger`). 

We have to subscribe to the timer publisher each time a new timer is created for the animations to continue after the already presented view using `Liquid()` is rendered again.