### PR TITLE
Add watchOS and tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_15),
         .watchOS(.v6),
+        .tvOS(.v13),
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "Liquid",
     platforms: [
         .iOS(.v13),
-        .macOS(SupportedPlatform.MacOSVersion.v10_15)
+        .macOS(.v10_15),
+        .watchOS(.v6),
     ],
     products: [
         .library(


### PR DESCRIPTION
I had lots of errors like this:

![Screenshot 2021-05-15 at 7 29 13 pm](https://user-images.githubusercontent.com/191085/118375185-f6d92280-b5b7-11eb-8868-79ce3282457e.png) <img width="260" alt="Screenshot 2021-05-17 at 10 13 35 am" src="https://user-images.githubusercontent.com/191085/118545037-fffbf800-b74d-11eb-9a13-159feec14137.png">

Adding `.watchOS(.v6)` (fixes #6) and `.tvOS(.v13)` to platforms resolved the issue for me.