### PR TITLE
Fix animation glitch on iOS 17

### DIFF
--- a/Sources/Liquid/PrivateViews/LiquidCircleView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidCircleView.swift
@@ -10,12 +10,14 @@ import SwiftUI
 struct LiquidCircleView: View {
     @State var samples: Int
     @State var radians: AnimatableArray
+    @State var animate: Bool
     let period: TimeInterval
 
-    init(samples: Int, period: TimeInterval) {
+    init(samples: Int, period: TimeInterval, animate: Bool) {
         self._samples = .init(initialValue: samples)
         self._radians = .init(initialValue: AnimatableArray(LiquidCircleView.generateRadial(samples)))
         self.period = period
+        self._animate = .init(initialValue: animate)
     }
 
     var body: some View {
@@ -23,10 +25,12 @@ struct LiquidCircleView: View {
             .onAppear {
                 animatedRadianUpdate()
             }
+            .onDisappear {
+                animate = false
+            }
     }
 
     static func generateRadial(_ count: Int = 6) -> [Double] {
-
         var radians: [Double] = []
         let offset = Double.random(in: 0...(.pi / Double(count)))
         for i in 0..<count {
@@ -39,6 +43,8 @@ struct LiquidCircleView: View {
     }
 
     func animatedRadianUpdate() {
+        guard animate else { return }
+        
         if #available(iOS 17.0, *) {
             withAnimation(.linear(duration: period)) {
                 radians = AnimatableArray(LiquidCircleView.generateRadial(samples))

--- a/Sources/Liquid/PrivateViews/LiquidPathView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidPathView.swift
@@ -38,6 +38,9 @@ struct LiquidPathView: View {
                 self.x = AnimatableArray(points.map { self.pointCloud.x[$0] })
                 self.y = AnimatableArray(points.map { self.pointCloud.y[$0] })
             }
+            Task.delayed(by: .seconds(period)) { @MainActor in
+                self.generate()
+            }
         }
     }
 

--- a/Sources/Liquid/PrivateViews/LiquidPathView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidPathView.swift
@@ -16,34 +16,35 @@ struct LiquidPathView: View {
     @State var y: AnimatableArray = .zero
     @State var samples: Int
     let period: TimeInterval
-    let trigger: Timer.TimerPublisher
-
-    var cancellable: Cancellable?
 
     init(path: CGPath, interpolate: Int, samples: Int, period: TimeInterval) {
         self._samples = .init(initialValue: samples)
         self.period = period
-        self.trigger = Timer.TimerPublisher(interval: period, runLoop: .main, mode: .common)
-        self.cancellable = self.trigger.connect()
         self.pointCloud = path.getPoints().interpolate(interpolate)
     }
 
     func generate() {
-        withAnimation(.linear(duration: period)) {
-            let points = Array(0..<pointCloud.x.count).randomElements(samples)
-            self.x = AnimatableArray(points.map { self.pointCloud.x[$0] })
-            self.y = AnimatableArray(points.map { self.pointCloud.y[$0] })
+        if #available(iOS 17.0, *) {
+            withAnimation(.linear(duration: period)) {
+                let points = Array(0..<pointCloud.x.count).randomElements(samples)
+                self.x = AnimatableArray(points.map { self.pointCloud.x[$0] })
+                self.y = AnimatableArray(points.map { self.pointCloud.y[$0] })
+            } completion: {
+                self.generate()
+            }
+        } else {
+            withAnimation(.linear(duration: period)) {
+                let points = Array(0..<pointCloud.x.count).randomElements(samples)
+                self.x = AnimatableArray(points.map { self.pointCloud.x[$0] })
+                self.y = AnimatableArray(points.map { self.pointCloud.y[$0] })
+            }
         }
     }
 
     var body: some View {
         LiquidPath(x: x, y: y)
-            .onReceive(trigger) { _ in
+            .onAppear {
                 self.generate()
-            }.onAppear {
-                self.generate()
-            }.onDisappear {
-                self.cancellable?.cancel()
             }
     }
 }

--- a/Sources/Liquid/PrivateViews/LiquidPathView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidPathView.swift
@@ -13,15 +13,19 @@ struct LiquidPathView: View {
     @State var x: AnimatableArray = .zero
     @State var y: AnimatableArray = .zero
     @State var samples: Int
+    @State var animate: Bool
     let period: TimeInterval
 
-    init(path: CGPath, interpolate: Int, samples: Int, period: TimeInterval) {
+    init(path: CGPath, interpolate: Int, samples: Int, period: TimeInterval, animate: Bool) {
         self._samples = .init(initialValue: samples)
         self.period = period
         self.pointCloud = path.getPoints().interpolate(interpolate)
+        self._animate = .init(initialValue: animate)
     }
 
     func generate() {
+        guard animate else { return }
+        
         if #available(iOS 17.0, *) {
             withAnimation(.linear(duration: period)) {
                 let points = Array(0..<pointCloud.x.count).randomElements(samples)
@@ -46,6 +50,9 @@ struct LiquidPathView: View {
         LiquidPath(x: x, y: y)
             .onAppear {
                 self.generate()
+            }
+            .onDisappear {
+                animate = false
             }
     }
 }

--- a/Sources/Liquid/PrivateViews/LiquidPathView.swift
+++ b/Sources/Liquid/PrivateViews/LiquidPathView.swift
@@ -6,11 +6,9 @@
 //
 
 import SwiftUI
-import Combine
 import Accelerate
 
 struct LiquidPathView: View {
-
     let pointCloud: (x: [Double], y: [Double])
     @State var x: AnimatableArray = .zero
     @State var y: AnimatableArray = .zero

--- a/Sources/Liquid/Processing/Extensions/Task+Delay.swift
+++ b/Sources/Liquid/Processing/Extensions/Task+Delay.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bence Borsos on 18/08/2024.
+//
+
+import Foundation
+
+extension Task where Failure == Error {
+    /// Create a delayed task that will wait for the given duration before performing its operation.
+    @discardableResult static func delayed(by delay: OperationQueue.SchedulerTimeType.Stride, priority: TaskPriority? = nil, operation: @escaping @Sendable () async throws -> Success) -> Task {
+        Task(priority: priority) {
+            try await Task<Never, Never>.sleep(nanoseconds: UInt64(delay.timeInterval * .nanosecondsPerSecond))
+            return try await operation()
+        }
+    }
+}

--- a/Sources/Liquid/Processing/Extensions/TimeInterval.swift
+++ b/Sources/Liquid/Processing/Extensions/TimeInterval.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bence Borsos on 18/08/2024.
+//
+
+import Foundation
+
+extension TimeInterval {
+    /// The number of nanoseconds in one second.
+    static let nanosecondsPerSecond = TimeInterval(NSEC_PER_SEC)
+}

--- a/Sources/Liquid/PublicViews/Liquid.swift
+++ b/Sources/Liquid/PublicViews/Liquid.swift
@@ -16,8 +16,8 @@ public struct Liquid: View {
     /// - Parameters:
     ///   - samples: number of points to sample along the circular path
     ///   - period: length of animation
-    public init(samples: Int = 8, period: TimeInterval = 6) {
-        self.content = AnyView(LiquidCircleView(samples: samples, period: period))
+    public init(samples: Int = 8, period: TimeInterval = 6, animate: Bool = true) {
+        self.content = AnyView(LiquidCircleView(samples: samples, period: period, animate: animate))
     }
     
     /// A blob resembling a custom path
@@ -26,9 +26,9 @@ public struct Liquid: View {
     ///   - interpolate: number of points along the path to up-sample
     ///   - samples: the number of samples to select at each animation
     ///   - period: length of animation
-    public init(_ path: CGPath, interpolate: Int, samples: Int, period: TimeInterval = 6) {
+    public init(_ path: CGPath, interpolate: Int, samples: Int, period: TimeInterval = 6, animate: Bool = true) {
         assert(interpolate > samples)
-        self.content = AnyView(LiquidPathView(path: path, interpolate: interpolate, samples: samples, period: period))
+        self.content = AnyView(LiquidPathView(path: path, interpolate: interpolate, samples: samples, period: period, animate: animate))
     }
     
     public var body: some View {

--- a/Sources/Liquid/PublicViews/Liquid.swift
+++ b/Sources/Liquid/PublicViews/Liquid.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Combine
 
 /// A flowing, liquid view
 public struct Liquid: View {


### PR DESCRIPTION
- Remove combine
- For iOS 17 or later use the new animation callback
- Below that use Task with a delay based on Liquid period
- Tested on physical devices running iOS 16, 17
